### PR TITLE
Fix mailgum header format for Reply-To,

### DIFF
--- a/Transport/MailgunApiTransport.php
+++ b/Transport/MailgunApiTransport.php
@@ -139,7 +139,7 @@ class MailgunApiTransport extends AbstractApiTransport
             if (\in_array($prefix, ['h:', 't:', 'o:', 'v:']) || \in_array($name, ['recipient-variables', 'template', 'amp-html'])) {
                 $headerName = $name;
             } else {
-                $headerName = 'h:'.$name;
+                $headerName = 'h:'.mb_convert_case($name, MB_CASE_TITLE, 'UTF-8');
             }
 
             $payload[$headerName] = $header->getBodyAsString();


### PR DESCRIPTION
In this moment is sent in lower case so: h:reply-to
You can see the article is h:Reply-To
https://help.mailgun.com/hc/en-us/articles/4401814149147-Adding-A-Reply-To-Address