### PR TITLE
Make MailgunHttpTransport->domain protected so it can be overwritten dynamically

### DIFF
--- a/Transport/MailgunHttpTransport.php
+++ b/Transport/MailgunHttpTransport.php
@@ -33,7 +33,7 @@ class MailgunHttpTransport extends AbstractHttpTransport
     private const HOST = 'api.%region_dot%mailgun.net';
 
     private $key;
-    private $domain;
+    protected $domain;
     private $region;
 
     public function __construct(string $key, string $domain, string $region = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)


### PR DESCRIPTION
Make domain protected so I can make mailgun use multi domain support: https://github.com/symfony/symfony/issues/46404

ideally i would like by default to get the `domain` from the sender's` email address but i think this PR would not be accepted. 

With this minimal change i can add multi domain support without too much code overwritting.


```php
class MailgunMultiDomainHttpTransport extends MailgunHttpTransport {
    protected function doSendHttp(SentMessage $message): ResponseInterface
    {
        $sender = $message->getEnvelope()->getSender();
        $fromEmail = $sender->getAddress();
        if ($fromEmail) {
            $this->domain = substr($fromEmail, strpos($fromEmail, '@') + 1);
        }
        return parent::doSendHttp($message);
    }
}
```