### PR TITLE
Add multi domain support to HTTP and Api

### DIFF
--- a/Tests/Transport/MailgunApiTransportTest.php
+++ b/Tests/Transport/MailgunApiTransportTest.php
@@ -37,19 +37,19 @@ class MailgunApiTransportTest extends TestCase
     {
         return [
             [
-                new MailgunApiTransport('ACCESS_KEY', 'DOMAIN'),
+                new MailgunApiTransport('ACCESS_KEY'),
                 'mailgun+api://api.mailgun.net?domain=DOMAIN',
             ],
             [
-                new MailgunApiTransport('ACCESS_KEY', 'DOMAIN', 'us-east-1'),
+                new MailgunApiTransport('ACCESS_KEY', 'us-east-1'),
                 'mailgun+api://api.us-east-1.mailgun.net?domain=DOMAIN',
             ],
             [
-                (new MailgunApiTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com'),
+                (new MailgunApiTransport('ACCESS_KEY'))->setHost('example.com'),
                 'mailgun+api://example.com?domain=DOMAIN',
             ],
             [
-                (new MailgunApiTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com')->setPort(99),
+                (new MailgunApiTransport('ACCESS_KEY'))->setHost('example.com')->setPort(99),
                 'mailgun+api://example.com:99?domain=DOMAIN',
             ],
         ];
@@ -71,7 +71,7 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->addTextHeader('amp-html', 'amp-html-value');
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $transport = new MailgunApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
@@ -107,7 +107,7 @@ class MailgunApiTransportTest extends TestCase
 
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $transport = new MailgunApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
@@ -119,7 +119,7 @@ class MailgunApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony/messages', $url);
+            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony.com/messages', $url);
             $this->assertStringContainsString('Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             $content = '';
@@ -136,7 +136,7 @@ class MailgunApiTransportTest extends TestCase
                 'http_code' => 200,
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us-east-1', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -165,7 +165,7 @@ class MailgunApiTransportTest extends TestCase
                 'http_code' => 200,
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us-east-1', $client);
 
         $mail = new Email();
         $mail->subject('Hello!')
@@ -196,7 +196,7 @@ class MailgunApiTransportTest extends TestCase
                 ],
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -225,7 +225,7 @@ class MailgunApiTransportTest extends TestCase
                 ],
             ]);
         });
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us', $client);
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'us', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -251,7 +251,7 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
-        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $transport = new MailgunApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $payload = $method->invoke($transport, $email, $envelope);
         $this->assertArrayHasKey('h:X-Mailgun-Variables', $payload);

--- a/Tests/Transport/MailgunHttpTransportTest.php
+++ b/Tests/Transport/MailgunHttpTransportTest.php
@@ -36,19 +36,19 @@ class MailgunHttpTransportTest extends TestCase
     {
         return [
             [
-                new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'),
+                new MailgunHttpTransport('ACCESS_KEY'),
                 'mailgun+https://api.mailgun.net?domain=DOMAIN',
             ],
             [
-                new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN', 'us-east-1'),
+                new MailgunHttpTransport('ACCESS_KEY', 'us-east-1'),
                 'mailgun+https://api.us-east-1.mailgun.net?domain=DOMAIN',
             ],
             [
-                (new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com'),
+                (new MailgunHttpTransport('ACCESS_KEY'))->setHost('example.com'),
                 'mailgun+https://example.com?domain=DOMAIN',
             ],
             [
-                (new MailgunHttpTransport('ACCESS_KEY', 'DOMAIN'))->setHost('example.com')->setPort(99),
+                (new MailgunHttpTransport('ACCESS_KEY'))->setHost('example.com')->setPort(99),
                 'mailgun+https://example.com:99?domain=DOMAIN',
             ],
         ];
@@ -58,7 +58,7 @@ class MailgunHttpTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony/messages.mime', $url);
+            $this->assertSame('https://api.us-east-1.mailgun.net:8984/v3/symfony.com/messages.mime', $url);
             $this->assertStringContainsString('Basic YXBpOkFDQ0VTU19LRVk=', $options['headers'][2] ?? $options['request_headers'][1]);
 
             $content = '';
@@ -75,7 +75,7 @@ class MailgunHttpTransportTest extends TestCase
                 'http_code' => 200,
             ]);
         });
-        $transport = new MailgunHttpTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+        $transport = new MailgunHttpTransport('ACCESS_KEY', 'us-east-1', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -103,7 +103,7 @@ class MailgunHttpTransportTest extends TestCase
                 ],
             ]);
         });
-        $transport = new MailgunHttpTransport('ACCESS_KEY', 'symfony', 'us', $client);
+        $transport = new MailgunHttpTransport('ACCESS_KEY', 'us', $client);
         $transport->setPort(8984);
 
         $mail = new Email();
@@ -126,7 +126,7 @@ class MailgunHttpTransportTest extends TestCase
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
 
-        $transport = new MailgunHttpTransport('key', 'domain');
+        $transport = new MailgunHttpTransport('key');
         $method = new \ReflectionMethod(MailgunHttpTransport::class, 'addMailgunHeaders');
         $method->invoke($transport, $email);
 

--- a/Tests/Transport/MailgunTransportFactoryTest.php
+++ b/Tests/Transport/MailgunTransportFactoryTest.php
@@ -67,32 +67,32 @@ class MailgunTransportFactoryTest extends TransportFactoryTestCase
 
         yield [
             new Dsn('mailgun+api', 'default', self::USER, self::PASSWORD),
-            new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunApiTransport(self::USER, null, $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+api', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu']),
-            new MailgunApiTransport(self::USER, self::PASSWORD, 'eu', $client, $dispatcher, $logger),
+            new MailgunApiTransport(self::USER, 'eu', $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+api', 'example.com', self::USER, self::PASSWORD, 8080),
-            (new MailgunApiTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailgunApiTransport(self::USER, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [
             new Dsn('mailgun', 'default', self::USER, self::PASSWORD),
-            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunHttpTransport(self::USER, null, $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+https', 'default', self::USER, self::PASSWORD),
-            new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger),
+            new MailgunHttpTransport(self::USER, null, $client, $dispatcher, $logger),
         ];
 
         yield [
             new Dsn('mailgun+https', 'example.com', self::USER, self::PASSWORD, 8080),
-            (new MailgunHttpTransport(self::USER, self::PASSWORD, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
+            (new MailgunHttpTransport(self::USER, null, $client, $dispatcher, $logger))->setHost('example.com')->setPort(8080),
         ];
 
         yield [

--- a/Transport/MailgunTransportFactory.php
+++ b/Transport/MailgunTransportFactory.php
@@ -31,11 +31,11 @@ final class MailgunTransportFactory extends AbstractTransportFactory
         $port = $dsn->getPort();
 
         if ('mailgun+api' === $scheme) {
-            return (new MailgunApiTransport($user, $password, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            return (new MailgunApiTransport($user, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
         }
 
         if ('mailgun+https' === $scheme || 'mailgun' === $scheme) {
-            return (new MailgunHttpTransport($user, $password, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            return (new MailgunHttpTransport($user, $region, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
         }
 
         if ('mailgun+smtp' === $scheme || 'mailgun+smtps' === $scheme) {


### PR DESCRIPTION
This changes make it possible to use the Mailer over multiple sender domains.

As the domain is must be based of the sender address otherwise Mailgun won't accept the Email. it doesn't make sense to hardcode the domain in the configuration.


### Before

```php
$transport = new MailgunHttpTransport('ACCESS_KEY', 'symfony', 'us', $client);
$transport->send(mailFrom("info@symfony.com")
```
would fail as domains are not correct: `symfony.com !== symfony`

### Now
```php
$transport = new MailgunHttpTransport('ACCESS_KEY', 'us', $client);
$transport->send(mailFrom("info@symfony.com")
```

Will send via the symfony.com domain. no domain setup necessary.


### Security concern (minor)

As before sending mails from `@other.domain` would fail at Mailgun side per default. 

now if you have multiple domains in Mailgun and you let the user fill in the the Sender/From address. It would allow a malicious user to send from any of your domains setup in Mailgun.

As letting the user decide the Sender address without any validation is very bad practise anyways i don't think this would be an issue.
